### PR TITLE
Changes the API URL to production

### DIFF
--- a/src/core/configs.js
+++ b/src/core/configs.js
@@ -4,7 +4,7 @@ import log from 'js-logger'
 
 var defaults = Object.freeze({
   logLevel:      'warn',
-  servicesUrl:   'https://testing.archilogic.com/api/v2',
+  servicesUrl:   'https://spaces.archilogic.com/api/v2',
   storageDomain: 'storage.3d.io',
   storageBucket: 'archilogic-content-beta'
 })


### PR DESCRIPTION
This avoids problems with making API requests against testing.
For instance: `S3.getCredentials` returns a key in the dev bucket, not in `storage.3d.io`