### PR TITLE
Load node-fetch from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "form-data": "^2.1.4",
     "js-logger": "^1.3.0",
     "lodash": "^4.17.4",
-    "node-fetch": "archilogic-com/node-fetch#1.x",
+    "node-fetch": "1.7.1",
     "rxjs": "^5.4.2",
     "three": "^0.85.2",
     "whatwg-fetch": "^2.0.3"

--- a/src/utils/data3d/load.js
+++ b/src/utils/data3d/load.js
@@ -3,7 +3,7 @@ import decodeBuffer from './decode-buffer.js'
 
 export default function loadData3d (url, options) {
   return fetch(url, options).then(function(res){
-    return res.arrayBuffer()
+    return res.buffer()
   }).then(function(buffer){
     return decodeBuffer(buffer, { url: url })
   })


### PR DESCRIPTION
Loading the original node-fetch from npm instead of github should cause no code-change, as the [arrayBuffer](https://github.com/archilogic-com/node-fetch/commit/dfed82c36c95e97767c1ecfabf2d9714eb25d1db) is already implemented in [node-fetch](https://github.com/bitinn/node-fetch/blob/60cf26c2f3baf566c15632b723664b47f5b1f2db/src/body.js#L67).
But it would allow loading the dependencies in a no git environment (f.e. docker).