### PR TITLE
Added account setup type to User.create credentials

### DIFF
--- a/src/utils/auth/sign-up.js
+++ b/src/utils/auth/sign-up.js
@@ -14,7 +14,8 @@ export default function signUp (args) {
 
   var credentials = {
     email: args.email,
-    password: args.password || uuid.generate()
+    password: args.password || uuid.generate(),
+    accountSetup: '3dio'
   }
 
   // log out first


### PR DESCRIPTION
I added the accountSetup argument to User.create credentials as a part of https://github.com/archilogic-com/services/issues/290 