### PR TITLE
Replaced shader includes with r87 normal_fragment.glsl

### DIFF
--- a/src/a-frame/three/data3d-view/io3d-material/fragment.glsl
+++ b/src/a-frame/three/data3d-view/io3d-material/fragment.glsl
@@ -40,7 +40,8 @@ void main() {
     #include <alphamap_fragment>
     #include <alphatest_fragment>
     #include <specularmap_fragment>
-    //include <normal_fragment>
+
+    // Start of <normal_fragment> replace block
     #ifdef FLAT_SHADED
 
       // Workaround for Adreno/Nexus5 not able able to do dFdx( vViewPosition ) ...
@@ -70,6 +71,7 @@ void main() {
       normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );
 
     #endif
+    // End of <normal_fragment> replace block
 
     // accumulation
     #include <lights_phong_fragment>

--- a/src/a-frame/three/data3d-view/io3d-material/fragment.glsl
+++ b/src/a-frame/three/data3d-view/io3d-material/fragment.glsl
@@ -40,8 +40,36 @@ void main() {
     #include <alphamap_fragment>
     #include <alphatest_fragment>
     #include <specularmap_fragment>
-    #include <normal_flip>
-    #include <normal_fragment>
+    //include <normal_fragment>
+    #ifdef FLAT_SHADED
+
+      // Workaround for Adreno/Nexus5 not able able to do dFdx( vViewPosition ) ...
+
+      vec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPosition.z ) );
+      vec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );
+      vec3 normal = normalize( cross( fdx, fdy ) );
+
+    #else
+
+      vec3 normal = normalize( vNormal );
+
+      #ifdef DOUBLE_SIDED
+
+        normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+      #endif
+
+    #endif
+
+    #ifdef USE_NORMALMAP
+
+      normal = perturbNormal2Arb( -vViewPosition, normal );
+
+    #elif defined( USE_BUMPMAP )
+
+      normal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );
+
+    #endif
 
     // accumulation
     #include <lights_phong_fragment>


### PR DESCRIPTION
Scope & Features:
- Three.js introduced breaking changes in r87, because they merged two shader includes into one
- The shader includes of our custom shaderMaterials were adjusted
- We need this change to stay compatible with the new aframe version

Design:
- Replaced shader includes with r87 normal_fragment.glsl
- Github Issue #57 

How to test:
- Test a 3d-js scene with data3d or furniture with the aframe 0.6.0 release
- Test it with a 0.7.0 release candidate
