### PR TITLE
Suggested improvements to get-id-from-url.js

### DIFF
--- a/src/storage/get-id-from-url.js
+++ b/src/storage/get-id-from-url.js
@@ -2,8 +2,8 @@ import configs from '../core/configs.js'
 
 // constants
 var URL_TO_ID_CACHE = {}
-var IS_HTTPS_URL = new RegExp('^https:\\/\\/storage\\.3d\\.io.*$')
-var IS_HTTP_URL = new RegExp('^http:\\/\\/storage\\.3d\\.io.*$')
+var IS_URL = new RegExp('^(http(s?))\\:\\/\\/(' + configs.storageDomain +'|' + configs.storageDomainNoCdn + ')')
+
 
 // main
 export default function getStorageIdFromUrl (url) {
@@ -11,16 +11,13 @@ export default function getStorageIdFromUrl (url) {
   // check cache
   if (URL_TO_ID_CACHE[url]) return URL_TO_ID_CACHE[url]
 
-  var storageId = url
-
-  if (IS_HTTPS_URL.test(url)) {
-    storageId = url.substring(21)
-  } else if (IS_HTTP_URL.test(url)) {
-    storageId = url.substring(20)
+  // check if url is valid url
+  if (IS_URL.test(url)) {
+    var storageId = url.replace(IS_URL, '')
+    // add to cache
+    URL_TO_ID_CACHE[ url ] = storageId
+    return storageId
+  } else {
+    throw new Error('Provided URL is not a valid URL:', url)
   }
-
-  // add to cache
-  URL_TO_ID_CACHE[ url ] = storageId
-  
-  return storageId
 }


### PR DESCRIPTION
Scope & Features:

I wrote this code for the modify app when it was not available and i realised there are some improvements that are worth pushing to 3d-io-js

- this makes get-id-from-url responsive to storageDomain from config, so it also works for testing environments
- throws an error instead of returning the input url, if the url is not a valid url. If this was intentional by design, I can adjust it.

How to use:
- test it like this:
`io3d.storage.getStorageIdFromUrl("https://storage.3d.io/535e624259ee6b0200000484/bake/2017-07-25_14-03-12_lXOHrN/lighting.gz.data3d.buffer")`
- should return the same result as master
- Now returns an error insted of returning the url:
`io3d.storage.getStorageIdFromUrl("bullshiturl/bake/lighting.gz.data3d.buffer")`
