### PR TITLE
Fix empty home staging result error

### DIFF
--- a/src/staging/get-furnishings.js
+++ b/src/staging/get-furnishings.js
@@ -81,12 +81,16 @@ function normalizeInput(input) {
 }
 
 function getSceneStructureFromFurnishingResult(result) {
-  var furnishing = result.furnishings
-  var spaceIds = Object.keys(furnishing)
-  if (!uuid.validate(spaceIds[0])) return Promise.reject('No furnishings were found')
+  // assumes that only one space is furnished at a time
+  var spaceId = Object.keys(result.furnishings)[0]
+
+  if (spaceId in result.errors) {
+    return Promise.reject(result.errors[spaceId])
+  }
 
   // get furniture groups from api result
-  var groups = furnishing[spaceIds[0]][0].groups
+  // assumes that only one result is requested from the home stagin API
+  var groups = result.furnishings[spaceId][0].groups
 
   // get normailzed sceneStructure for each furniture group
   return Promise.map(groups, getFurnitureGroupData)


### PR DESCRIPTION
If no results are produced for an `io3d.staging.getFurnishings` call, currently, the library rejects the promise with the message: `TypeError: Cannot read property 'groups' of undefined`.

This pull request changes this behaviour to reject the promise with the error message from the Home Staging API, which would be `No valid furnishings were found.` if no results are returned.

The change was tested by going through the "staging" examples.