### PR TITLE
Expose getFurnitureAlternatives

### DIFF
--- a/examples-browser/staging/replace-furniture/index.html
+++ b/examples-browser/staging/replace-furniture/index.html
@@ -12,7 +12,8 @@
       <input id="inpt-id" placeholder="enter id" style="width: 200px;"/>
       <input id="inpt-filter" placeholder="filter results" style="width: 100px;"/>
     </div>
-    <a-scene antialias="true" shadow="type: pcfsoft">
+    <div id="panel" style="position:absolute; overflow: auto; white-space: nowrap; padding:10px; vertical-align:top; bottom: 0; width: 100%; height: 120px; z-index: 1000; background: white"></div>
+    <a-scene antialias="true" shadow="type: pcfsoft" vr-mode-ui="enabled: false" embedded style="height: calc(100vh - 120px)">
       <a-entity light="type:directional; castShadow: true; intensity:0.3; shadowMapHeight:1024; shadowMapWidth:1024;" position="4 3 3"></a-entity>
       <a-entity light="type:ambient; color:#bbb" position="0 5 3"></a-entity>
       <a-entity id="furniture" io3d-furniture position="0 0 -3" rotation="0 0 0" shadow="cast:true; receive:false;">
@@ -30,14 +31,18 @@
       <a-camera></a-camera>
     </a-scene>
     <script>
-      furnitureId = 'edd99bfc-a597-4fb4-bf92-04916e6d5dfc'
       const furnitureEl = document.querySelector('a-entity#furniture')
       const rndBtn = document.querySelector('#rnd-btn')
       const idInput = document.querySelector('input#inpt-id')
       const queryInput = document.querySelector('input#inpt-filter')
       const changeBtn = document.querySelector('#change-btn')
+      const panelEl = document.querySelector('#panel')
+
+      let alternatives = []
       // preset id input
       idInput.value = furniture.getAttribute('io3d-furniture').id
+
+      getAlternatives(idInput.value)
 
       idInput.addEventListener('input', function() {
         var furnitureId = idInput.value
@@ -52,6 +57,8 @@
           furniture.setAttribute('io3d-furniture', {'id': furnitureInfo.id})
           furniture.setAttribute('position', '0 0 -3')
           idInput.value = furnitureInfo.id
+          // find alternative items
+          getAlternatives(furnitureInfo.id)
         })
       })
       changeBtn.addEventListener('click', function() {
@@ -61,21 +68,57 @@
           .then(result => {
             if (!result) return
 
-            //var elements = io3d.scene.getHtmlFromSceneStructure(result)
             console.log(result)
 
             // apply values from result
             furnitureEl.setAttribute('position', result.components.position.attrValue)
             furnitureEl.setAttribute('io3d-furniture', result.components['io3d-furniture'].attrValue)
-
-            // alternative: replace node with new node
-            // furnitureEl.parentNode.replaceChild(elements[0], furnitureEl)
+            // find alternative items
+            getAlternatives(result.components['io3d-furniture'].attrValue.id)
           })
       })
+
+      function replaceFurniture(el) {
+        let newPos = getNewPosition(furnitureEl, el.offset)
+        furnitureEl.setAttribute('position', newPos)
+        furnitureEl.setAttribute('io3d-furniture', {id: el.furniture.id})
+        getAlternatives(el.furniture.id)
+      }
+
+      function getAlternatives(id) {
+        io3d.staging.getFurnitureAlternatives(id)
+          .then(result => {
+            console.log(result.length, 'elements found')
+            if (result) {
+              alternatives = result
+              let images = result.map(item => item.furniture.thumb)
+              let imgStr = ''
+              images.forEach((img, i) => {
+                imgStr += `<img height="100" onclick="replaceFurniture(alternatives[${i}])" style="display:inline-block;     max-width: 180px;; margin-right: 10px;" src="${img}"></img>`
+              })
+              panelEl.innerHTML = imgStr
+            } else panelEl.innerHTML = 'nothing found =('
+
+          })
+      }
 
       function validateUuid (str) {
         if (!str || typeof str !== "string") return false
         return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(str)
+      }
+
+      // compute new position based on bounding boxes
+      function getNewPosition(el, offset) {
+        let element3d = el.getAttribute('position')
+        element3d.ry = el.getAttribute('rotation').y
+        var s = Math.sin(element3d.ry / 180 * Math.PI)
+        var c = Math.cos(element3d.ry / 180 * Math.PI)
+        var newPosition = {
+          x: element3d.x + offset.x * c + offset.z * s,
+          y: element3d.y + offset.y,
+          z: element3d.z - offset.x * s + offset.z * c
+        }
+        return newPosition
       }
     </script>
   </body>

--- a/examples-browser/staging/replace-furniture/index.html
+++ b/examples-browser/staging/replace-furniture/index.html
@@ -12,8 +12,8 @@
       <input id="inpt-id" placeholder="enter id" style="width: 250px;"/>
       <input id="inpt-filter" placeholder="filter results" style="width: 150px;"/>
     </div>
-    <div id="panel" style="position:absolute; overflow: auto; white-space: nowrap; padding:10px; vertical-align:top; bottom: 0; width: 100%; height: 120px; z-index: 1000; background: white"></div>
-    <a-scene antialias="true" shadow="type: pcfsoft" vr-mode-ui="enabled: false" embedded style="height: calc(100vh - 120px)">
+    <div id="panel" style="position:absolute; overflow: auto; white-space: nowrap; padding:15px; vertical-align:top; bottom: 0; width: 100%; height: 150px; z-index: 1000; background: white"></div>
+    <a-scene antialias="true" shadow="type: pcfsoft" vr-mode-ui="enabled: false" embedded style="height: calc(100vh - 150px)">
       <a-entity light="type:directional; castShadow: true; intensity:0.3; shadowMapHeight:1024; shadowMapWidth:1024;" position="4 3 3"></a-entity>
       <a-entity light="type:ambient; color:#bbb" position="0 5 3"></a-entity>
       <a-entity id="furniture" io3d-furniture position="0 0 -3" rotation="0 0 0" shadow="cast:true; receive:false;">
@@ -32,6 +32,7 @@
     </a-scene>
     <script>
       // 38e0fe6d-2a95-49f9-94fd-7fddc7db1b5d
+//      bf209a61-c34a-4f72-9bf5-2610a99e6572
       const furnitureEl = document.querySelector('a-entity#furniture')
       const rndBtn = document.querySelector('#rnd-btn')
       const idInput = document.querySelector('input#inpt-id')
@@ -93,8 +94,8 @@
       function getAlternatives(id) {
         io3d.staging.getFurnitureAlternatives(id)
           .then(result => {
-            console.log(result.length, 'elements found')
             if (result) {
+              console.log(result.length, 'elements found')
               alternatives = result
               let images = result.map(item => item.furniture.thumb)
               let imgStr = ''

--- a/examples-browser/staging/replace-furniture/index.html
+++ b/examples-browser/staging/replace-furniture/index.html
@@ -9,8 +9,8 @@
     <div class="controls">
       <button id="rnd-btn">pick random</button>
       <button id="change-btn">replace with similar furniture</button><br>
-      <input id="inpt-id" placeholder="enter id" style="width: 200px;"/>
-      <input id="inpt-filter" placeholder="filter results" style="width: 100px;"/>
+      <input id="inpt-id" placeholder="enter id" style="width: 250px;"/>
+      <input id="inpt-filter" placeholder="filter results" style="width: 150px;"/>
     </div>
     <div id="panel" style="position:absolute; overflow: auto; white-space: nowrap; padding:10px; vertical-align:top; bottom: 0; width: 100%; height: 120px; z-index: 1000; background: white"></div>
     <a-scene antialias="true" shadow="type: pcfsoft" vr-mode-ui="enabled: false" embedded style="height: calc(100vh - 120px)">
@@ -31,6 +31,7 @@
       <a-camera></a-camera>
     </a-scene>
     <script>
+      // 38e0fe6d-2a95-49f9-94fd-7fddc7db1b5d
       const furnitureEl = document.querySelector('a-entity#furniture')
       const rndBtn = document.querySelector('#rnd-btn')
       const idInput = document.querySelector('input#inpt-id')
@@ -42,11 +43,15 @@
       // preset id input
       idInput.value = furniture.getAttribute('io3d-furniture').id
 
-      getAlternatives(idInput.value)
+      getAlternatives(idInput.value, {query: queryInput.value})
 
       idInput.addEventListener('input', function() {
         var furnitureId = idInput.value
-        if (validateUuid(furnitureId)) furniture.setAttribute('io3d-furniture', {'id': furnitureId})
+        if (validateUuid(furnitureId)) {
+          furniture.setAttribute('io3d-furniture', {'id': furnitureId})
+          // find alternative items
+          getAlternatives(furnitureId, {query: queryInput.value})
+        }
         else io3d.ui.message('no valid id', 4000, 'warning')
       })
       rndBtn.addEventListener('click', function() {
@@ -58,7 +63,7 @@
           furniture.setAttribute('position', '0 0 -3')
           idInput.value = furnitureInfo.id
           // find alternative items
-          getAlternatives(furnitureInfo.id)
+          getAlternatives(furnitureInfo.id, {query: queryInput.value})
         })
       })
       changeBtn.addEventListener('click', function() {
@@ -74,7 +79,7 @@
             furnitureEl.setAttribute('position', result.components.position.attrValue)
             furnitureEl.setAttribute('io3d-furniture', result.components['io3d-furniture'].attrValue)
             // find alternative items
-            getAlternatives(result.components['io3d-furniture'].attrValue.id)
+            getAlternatives(result.components['io3d-furniture'].attrValue.id, {query: queryInput.value})
           })
       })
 
@@ -82,7 +87,7 @@
         let newPos = getNewPosition(furnitureEl, el.offset)
         furnitureEl.setAttribute('position', newPos)
         furnitureEl.setAttribute('io3d-furniture', {id: el.furniture.id})
-        getAlternatives(el.furniture.id)
+        getAlternatives(el.furniture.id, {query: queryInput.value})
       }
 
       function getAlternatives(id) {
@@ -100,6 +105,7 @@
             } else panelEl.innerHTML = 'nothing found =('
 
           })
+          .catch(console.error)
       }
 
       function validateUuid (str) {

--- a/examples-browser/staging/style.css
+++ b/examples-browser/staging/style.css
@@ -1,3 +1,8 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
 input {
   height: 30px;
   font-size: 16px;

--- a/src/staging.js
+++ b/src/staging.js
@@ -1,8 +1,10 @@
 import getFurnishings from './staging/get-furnishings.js'
 import replaceFurniture from './staging/replace-furniture.js'
+import getFurnitureAlternatives from './staging/get-furniture-alternatives.js'
 
 var staging = {
   getFurnishings: getFurnishings,
+  getFurnitureAlternatives: getFurnitureAlternatives,
   replaceFurniture: replaceFurniture
 }
 

--- a/src/staging/get-furniture-alternatives.js
+++ b/src/staging/get-furniture-alternatives.js
@@ -42,9 +42,9 @@ var config = {
   ]
 }
 
-export default function getAlternatives(id, query) {
-  var options = {
-    userQuery: query || null,
+export default function getAlternatives(id, options) {
+  options = {
+    userQuery: options.query || null,
     searchCount: 0,
     margin: config['default_margin']
   }

--- a/src/staging/get-furniture-alternatives.js
+++ b/src/staging/get-furniture-alternatives.js
@@ -61,7 +61,9 @@ export default function getAlternatives(id, options) {
     .then(function(result) {
       return verifyResult(result, id, params)
     })
-    .catch(function(error) {})
+    .catch(function(error) {
+      console.error()
+    })
 }
 
 function verifyResult(result, id, params) {
@@ -104,7 +106,6 @@ function verifyResult(result, id, params) {
 function getQuery(params) {
   var info = params.info
   var queries = [config['default_search']]
-  var dimensions = ['length', 'height', 'width']
   var includeCategories = params.searchCount < 6
   var tags = includeCategories ? info.tags.concat(info.categories) : info.tags
 
@@ -128,12 +129,10 @@ function getQuery(params) {
   // add dimension search params if source provides dimensions
   var dim = info.boundingBox
   if (dim) {
-    ;['length', 'height', 'width'].forEach(function(d) {
+    ['length', 'height', 'width'].forEach(function(d) {
       if (dim[d] - params.margin > 0) {
-        searchQuery[d + 'Min'] =
-          Math.round((dim[d] - params.margin) * 1e2) / 1e2
-        searchQuery[d + 'Max'] =
-          Math.round((dim[d] + params.margin) * 1e2) / 1e2
+        searchQuery[d + 'Min'] = Math.round((dim[d] - params.margin) * 1e2) / 1e2
+        searchQuery[d + 'Max'] = Math.round((dim[d] + params.margin) * 1e2) / 1e2
       }
     })
   }

--- a/src/staging/get-furniture-alternatives.js
+++ b/src/staging/get-furniture-alternatives.js
@@ -62,7 +62,7 @@ export default function getAlternatives(id, options) {
       return verifyResult(result, id, params)
     })
     .catch(function(error) {
-      console.error()
+      console.error(error)
     })
 }
 

--- a/src/staging/get-furniture-alternatives.js
+++ b/src/staging/get-furniture-alternatives.js
@@ -56,7 +56,6 @@ export default function getAlternatives(id, options) {
   return getFurnitureInfo(id)
     .then(function(info) {
       params.info = info
-      var query = getQuery(params)
       return search(getQuery(params))
     })
     .then(function(result) {

--- a/src/staging/get-furniture-alternatives.js
+++ b/src/staging/get-furniture-alternatives.js
@@ -68,7 +68,6 @@ export default function getAlternatives(id, options) {
 
 function verifyResult(result, id, params) {
   var info = params.info
-
   if (params.searchCount > 10) {
     return Promise.reject(new Error('No furniture was found'))
   }
@@ -82,7 +81,7 @@ function verifyResult(result, id, params) {
 
   if (rawResult.length < 1) {
     if (params.searchCount >= 3) params.margin += 0.1
-    var searchQuery = getQuery(info, params)
+    var searchQuery = getQuery(params)
     params.searchCount += 1
     return search(searchQuery)
       .then(function(result) {
@@ -125,7 +124,6 @@ function getQuery(params) {
   if (params.userQuery && tags.indexOf('TV') < 0)
     queries = queries.concat(params.userQuery)
   var searchQuery = { query: queries.join(' ') }
-
   // add dimension search params if source provides dimensions
   var dim = info.boundingBox
   if (dim) {

--- a/src/staging/get-furniture-alternatives.js
+++ b/src/staging/get-furniture-alternatives.js
@@ -117,10 +117,8 @@ function getQuery(options) {
   }
 
   queries = queries.concat(tags)
-  console.log('debugging q', queries)
   if (options.userQuery && tags.indexOf('TV') < 0)
     queries = queries.concat(options.userQuery)
-  console.log('debugging q', queries)
   var searchQuery = { query: queries.join(' ') }
 
   // add dimension search params if source provides dimensions

--- a/src/staging/replace-furniture.js
+++ b/src/staging/replace-furniture.js
@@ -8,8 +8,7 @@ import Promise from 'bluebird'
 // consumes sceneStructure or DOM elements
 // replaces furniture Ids and adjusts positioning
 // outputs input type
-export default function replaceFurniture (input, options) {
-
+export default function replaceFurniture(input, options) {
   options = options || {}
   var query = options.query
   // defaults to pick a random item from alternatives
@@ -27,13 +26,13 @@ export default function replaceFurniture (input, options) {
     .then(function(sceneStructure) {
       furnitureIds = getIdsFromSceneStructure(sceneStructure)
 
-      if (Object.keys(furnitureIds).length === 0) return Promise.reject('No valid furniture elements were found')
+      if (Object.keys(furnitureIds).length === 0)
+        return Promise.reject('No valid furniture elements were found')
 
       var promises = []
       Object.keys(furnitureIds).forEach(function(id) {
         promises.push(new GetFurnitureAlternatives(id, options))
       })
-
       return Promise.all(promises)
     })
     .then(function(result) {
@@ -43,7 +42,11 @@ export default function replaceFurniture (input, options) {
       })
 
       // replace params in furniture elements
-      var sceneStructure = updateSceneStructureWithResult(input, alternatives, random)
+      var sceneStructure = updateSceneStructureWithResult(
+        input,
+        alternatives,
+        random
+      )
       if (isDomElement) {
         return getAframeElementsFromSceneStructure(sceneStructure)
       } else return sceneStructure
@@ -61,10 +64,19 @@ function getIdsFromSceneStructure(sceneStructure) {
   var collection = {}
   sceneStructure.forEach(function(element3d) {
     // get all furniture elements = type: 'interior'
-    if (element3d.type === 'interior' && element3d.src && typeof element3d.src === 'string') collection[element3d.src.substring(1)] = true
+    if (
+      element3d.type === 'interior' &&
+      element3d.src &&
+      typeof element3d.src === 'string'
+    )
+      collection[element3d.src.substring(1)] = true
     // recursively search through scene structure
     if (element3d.children && element3d.children.length) {
-      collection = defaults({}, collection, getIdsFromSceneStructure (element3d.children))
+      collection = defaults(
+        {},
+        collection,
+        getIdsFromSceneStructure(element3d.children)
+      )
     }
   })
   return collection
@@ -72,21 +84,22 @@ function getIdsFromSceneStructure(sceneStructure) {
 
 // Returns true if it is a DOM element
 // https://stackoverflow.com/a/384380/2835973
-function isElement(o){
-  return (
-    typeof HTMLElement === "object" ? o instanceof HTMLElement : //DOM2
-      o && typeof o === "object" && o !== null && o.nodeType === 1 && typeof o.nodeName==="string"
-  );
+function isElement(o) {
+  return typeof HTMLElement === 'object'
+    ? o instanceof HTMLElement //DOM2
+    : o &&
+      typeof o === 'object' &&
+      o !== null &&
+      o.nodeType === 1 &&
+      typeof o.nodeName === 'string'
 }
 
 function updateSceneStructureWithResult(input, alternatives, random) {
-  var
-    sceneStructure = input,
+  var sceneStructure = input,
     replacement,
     index = 0
 
   Object.keys(alternatives).forEach(function(id) {
-
     if (!alternatives[id] || !alternatives[id].length) return
     // we the pick a random item or take the first one
     if (random) index = Math.floor(Math.random() * alternatives[id].length)
@@ -105,7 +118,11 @@ function updateElementsById(sceneStructure, id, replacement) {
 
   sceneStructure = sceneStructure.map(function(element3d) {
     // furniture id is stored in src param
-    if (element3d.type === 'interior' && element3d.src.substring(1) === id && replacement.furniture) {
+    if (
+      element3d.type === 'interior' &&
+      element3d.src.substring(1) === id &&
+      replacement.furniture
+    ) {
       // apply new id
       element3d.src = '!' + replacement.furniture.id
       // compute new position for items that differ in size and mesh origin
@@ -117,7 +134,11 @@ function updateElementsById(sceneStructure, id, replacement) {
     }
     // recursivley search tree
     if (element3d.children && element3d.children.length) {
-      element3d.children = updateElementsById(element3d.children, id, replacement)
+      element3d.children = updateElementsById(
+        element3d.children,
+        id,
+        replacement
+      )
     }
     return element3d
   })
@@ -127,7 +148,6 @@ function updateElementsById(sceneStructure, id, replacement) {
 
 // compute new position based on bounding boxes
 function getNewPosition(element3d, offset) {
-
   var s = Math.sin(element3d.ry / 180 * Math.PI)
   var c = Math.cos(element3d.ry / 180 * Math.PI)
   var newPosition = {

--- a/src/staging/replace-furniture.js
+++ b/src/staging/replace-furniture.js
@@ -8,7 +8,8 @@ import Promise from 'bluebird'
 // consumes sceneStructure or DOM elements
 // replaces furniture Ids and adjusts positioning
 // outputs input type
-export default function replaceFurniture(input, options) {
+export default function replaceFurniture (input, options) {
+
   options = options || {}
   var query = options.query
   // defaults to pick a random item from alternatives
@@ -26,13 +27,13 @@ export default function replaceFurniture(input, options) {
     .then(function(sceneStructure) {
       furnitureIds = getIdsFromSceneStructure(sceneStructure)
 
-      if (Object.keys(furnitureIds).length === 0)
-        return Promise.reject('No valid furniture elements were found')
+      if (Object.keys(furnitureIds).length === 0) return Promise.reject('No valid furniture elements were found')
 
       var promises = []
       Object.keys(furnitureIds).forEach(function(id) {
         promises.push(getFurnitureAlternatives(id, options))
       })
+
       return Promise.all(promises)
     })
     .then(function(result) {
@@ -42,8 +43,7 @@ export default function replaceFurniture(input, options) {
       })
 
       // replace params in furniture elements
-      var sceneStructure = updateSceneStructureWithResult( input, alternatives, random)
-
+      var sceneStructure = updateSceneStructureWithResult(input, alternatives, random)
       if (isDomElement) {
         return getAframeElementsFromSceneStructure(sceneStructure)
       } else return sceneStructure
@@ -61,12 +61,7 @@ function getIdsFromSceneStructure(sceneStructure) {
   var collection = {}
   sceneStructure.forEach(function(element3d) {
     // get all furniture elements = type: 'interior'
-    if (
-      element3d.type === 'interior' &&
-      element3d.src &&
-      typeof element3d.src === 'string'
-    )
-      collection[element3d.src.substring(1)] = true
+    if (element3d.type === 'interior' && element3d.src && typeof element3d.src === 'string') collection[element3d.src.substring(1)] = true
     // recursively search through scene structure
     if (element3d.children && element3d.children.length) {
       collection = defaults({}, collection, getIdsFromSceneStructure (element3d.children))
@@ -77,22 +72,21 @@ function getIdsFromSceneStructure(sceneStructure) {
 
 // Returns true if it is a DOM element
 // https://stackoverflow.com/a/384380/2835973
-function isElement(o) {
-  return typeof HTMLElement === 'object'
-    ? o instanceof HTMLElement //DOM2
-    : o &&
-      typeof o === 'object' &&
-      o !== null &&
-      o.nodeType === 1 &&
-      typeof o.nodeName === 'string'
+function isElement(o){
+  return (
+    typeof HTMLElement === "object" ? o instanceof HTMLElement : //DOM2
+      o && typeof o === "object" && o !== null && o.nodeType === 1 && typeof o.nodeName==="string"
+  );
 }
 
 function updateSceneStructureWithResult(input, alternatives, random) {
-  var sceneStructure = input,
+  var
+    sceneStructure = input,
     replacement,
     index = 0
 
   Object.keys(alternatives).forEach(function(id) {
+
     if (!alternatives[id] || !alternatives[id].length) return
     // we the pick a random item or take the first one
     if (random) index = Math.floor(Math.random() * alternatives[id].length)
@@ -111,11 +105,7 @@ function updateElementsById(sceneStructure, id, replacement) {
 
   sceneStructure = sceneStructure.map(function(element3d) {
     // furniture id is stored in src param
-    if (
-      element3d.type === 'interior' &&
-      element3d.src.substring(1) === id &&
-      replacement.furniture
-    ) {
+    if (element3d.type === 'interior' && element3d.src.substring(1) === id && replacement.furniture) {
       // apply new id
       element3d.src = '!' + replacement.furniture.id
       // compute new position for items that differ in size and mesh origin
@@ -127,11 +117,7 @@ function updateElementsById(sceneStructure, id, replacement) {
     }
     // recursivley search tree
     if (element3d.children && element3d.children.length) {
-      element3d.children = updateElementsById(
-        element3d.children,
-        id,
-        replacement
-      )
+      element3d.children = updateElementsById(element3d.children, id, replacement)
     }
     return element3d
   })
@@ -141,6 +127,7 @@ function updateElementsById(sceneStructure, id, replacement) {
 
 // compute new position based on bounding boxes
 function getNewPosition(element3d, offset) {
+
   var s = Math.sin(element3d.ry / 180 * Math.PI)
   var c = Math.cos(element3d.ry / 180 * Math.PI)
   var newPosition = {

--- a/src/staging/replace-furniture.js
+++ b/src/staging/replace-furniture.js
@@ -1,4 +1,4 @@
-import GetFurnitureAlternatives from './get-furniture-alternatives.js'
+import getFurnitureAlternatives from './get-furniture-alternatives.js'
 import getSceneStructureFromAframeElements from '../scene/structure/from-aframe-elements.js'
 import getAframeElementsFromSceneStructure from '../scene/structure/to-aframe-elements.js'
 import normalizeSceneStructure from '../scene/structure/normalize.js'
@@ -31,7 +31,7 @@ export default function replaceFurniture(input, options) {
 
       var promises = []
       Object.keys(furnitureIds).forEach(function(id) {
-        promises.push(new GetFurnitureAlternatives(id, options))
+        promises.push(getFurnitureAlternatives(id, options))
       })
       return Promise.all(promises)
     })

--- a/src/staging/replace-furniture.js
+++ b/src/staging/replace-furniture.js
@@ -42,11 +42,8 @@ export default function replaceFurniture(input, options) {
       })
 
       // replace params in furniture elements
-      var sceneStructure = updateSceneStructureWithResult(
-        input,
-        alternatives,
-        random
-      )
+      var sceneStructure = updateSceneStructureWithResult( input, alternatives, random)
+
       if (isDomElement) {
         return getAframeElementsFromSceneStructure(sceneStructure)
       } else return sceneStructure
@@ -72,11 +69,7 @@ function getIdsFromSceneStructure(sceneStructure) {
       collection[element3d.src.substring(1)] = true
     // recursively search through scene structure
     if (element3d.children && element3d.children.length) {
-      collection = defaults(
-        {},
-        collection,
-        getIdsFromSceneStructure(element3d.children)
-      )
+      collection = defaults({}, collection, getIdsFromSceneStructure (element3d.children))
     }
   })
   return collection


### PR DESCRIPTION
This PR refactors get-furniture-alternatives so it can be used as a function and exposes it as `io3d.staging.getFurnitureAlternatives`

Example usage:

```
io3d.staging
  .getFurnitureAlternatives('c4af7f4e-cd4d-45f5-8b31-1aaa903d539e', {query: 'vitra'})

// [ { 'furniture': { ...furnitureInfo }, 'offset': { x, y, z }, .... ]
```
