### PR TITLE
Added io3d.modify.collisionObject API

### DIFF
--- a/src/modify.js
+++ b/src/modify.js
@@ -1,8 +1,9 @@
 import modifyModel from './modify/modify-model.js'
 
 var modify = {
-  origami: modifyModel.origami,
-  consolidateFaceSides: modifyModel.consolidateFaceSides
+  collisionObject: modifyModel.collisionObject,
+  consolidateFaceSides: modifyModel.consolidateFaceSides,
+  origami: modifyModel.origami
 }
 
 export default modify

--- a/src/modify/modify-model.js
+++ b/src/modify/modify-model.js
@@ -22,6 +22,7 @@ function getModifier(modifier) {
 // expose api
 
 export default {
-  origami: getModifier('origami'),
-  consolidateFaceSides: getModifier('consolidateFaceSides')
+  collisionObject: getModifier('collisionObject'),
+  consolidateFaceSides: getModifier('consolidateFaceSides'),
+  origami: getModifier('origami')
 }


### PR DESCRIPTION
**Feature Overview**
- This feature is to create low-poly collision meshes intended for the use with physics engines
- Using box colliders or spherical colliders is very limited and does not work for more complex 3d models
- Instead of using the original mesh for collision, this feature proposes to use very simple meshes just for the collision (invisible for the user) for better results and better physics performance (instead of using the original mesh)

**Design**
- The process creates a mesh of the bounding box of the object
- Then the mesh is subdivided and *shrinkwrapped* around the original mesh, this creates a simplified mesh that also should not have concave parts (better for collision detection)
- There will be additional settings to determine how many subdivisions the original 
<img width="243" alt="screen shot 2017-10-29 at 10 45 26" src="https://user-images.githubusercontent.com/25610447/32178175-625371a0-bd8c-11e7-87ad-aa218fa3b9fe.png">

**How to use**
- Test it with testing web-server setup in configs
```
var storageId = '/535e624259ee6b0200000484/170511-1605-ti05qg/archilogic_2017-05-11_16-05-27_vNIa8r.gz.data3d.buffer'

  io3d.modify.collisionObject(storageId)
    .then(io3d.utils.processing.whenDone)
    .then(io3d.storage.getUrlFromStorageId)
    .then(console.log)
```

**Notes**
- Test after services PR has been merged to master
- Merge after API has been released to production in the backend 
- [Services](https://github.com/archilogic-com/services/pull/386)