### PR TITLE
- Implemented saturation parameter for lightmaps [#85]

### DIFF
--- a/src/aframe/component/data3d.js
+++ b/src/aframe/component/data3d.js
@@ -34,6 +34,16 @@ export default {
         }
         return -100.0 // = fallback to value from data3d file
       }
+    },
+    lightMapSaturation: {
+      type: 'float',
+      default: 1.0,
+      parse: function (value) {
+        if (parseFloat(value)) {
+          return parseFloat(value)
+        }
+        return 1.0
+      }
     }
   },
 
@@ -47,6 +57,7 @@ export default {
     var scene = this_.data.scene
     var lightMapIntensity = this_.data.lightMapIntensity
     var lightMapExposure = this_.data.lightMapExposure
+    var lightMapSaturation = this_.data.lightMapSaturation
 
     if(scene !== '') {
       callService('Model.read', {arguments: { resourceId: scene}}).then(function onResult(result) {
@@ -98,6 +109,7 @@ export default {
       this_.data3dView.set(data3d, {
         lightMapIntensity: lightMapIntensity,
         lightMapExposure: lightMapExposure,
+        lightMapSaturation: lightMapSaturation,
         loadingQueuePrefix: 'architecture'
       })
       this_.el.setObject3D('mesh', this_.mesh)

--- a/src/aframe/three/data3d-view.js
+++ b/src/aframe/three/data3d-view.js
@@ -61,7 +61,8 @@ export default checkDependencies({
         loadingQueuePrefix = data3d.loadingQueuePrefix || options.loadingQueuePrefix || 'architecture',
         onFirstTextureSetLoaded = options.onFirstTextureSetLoaded,
         lightMapIntensity = options.lightMapIntensity,
-        lightMapExposure = options.lightMapExposure
+        lightMapExposure = options.lightMapExposure,
+        lightMapSaturation = options.lightMapSaturation
 
       // internals
       var self = this, meshId, mesh, materialId, wireframe3d, positions, uvs, uvs2, scale,
@@ -286,7 +287,8 @@ export default checkDependencies({
               attributes: materials[ materialId ],
               onFirstTextureSetLoaded: onFirstTextureSetLoaded,
               lightMapIntensity: lightMapIntensity,
-              lightMapExposure: lightMapExposure
+              lightMapExposure: lightMapExposure,
+              lightMapSaturation: lightMapSaturation
             })
           }
 

--- a/src/aframe/three/data3d-view/io3d-material.js
+++ b/src/aframe/three/data3d-view/io3d-material.js
@@ -11,7 +11,8 @@ export default checkDependencies ({
 
   var DEFAULT_LIGHT_MAP_INTENSITY = 1.2
   var DEFAULT_LIGHT_MAP_EXPOSURE = 0.6
-  var DEFAULT_LIGHT_MAP_FALLOFF = 0
+  var DEFAULT_LIGHT_MAP_FALLOFF = 0.0
+  var DEFAULT_LIGHT_MAP_SATURATION = 1.0
   var DEFAULT_NORMAL_MAP_FACTOR = new THREE.Vector2(0.8, 0.8)
 
   // main
@@ -22,6 +23,7 @@ export default checkDependencies ({
     var params = params || {}
     this.lightMapExposure = params.lightMapExposure || DEFAULT_LIGHT_MAP_EXPOSURE
     this.lightMapFalloff = params.lightMapFalloff || DEFAULT_LIGHT_MAP_FALLOFF
+    this.lightMapSaturation = params.lightMapSaturation || DEFAULT_LIGHT_MAP_SATURATION
 
     this.uniforms = THREE.UniformsUtils.merge( [
       THREE.UniformsLib[ "lights" ],
@@ -34,6 +36,7 @@ export default checkDependencies ({
         lightMapIntensity: { value: params.lightMapIntensity || DEFAULT_LIGHT_MAP_INTENSITY },
         lightMapFalloff: { value: params.lightMapFalloff || DEFAULT_LIGHT_MAP_FALLOFF },
         lightMapExposure: { value: params.lightMapExposure || DEFAULT_LIGHT_MAP_EXPOSURE },
+        lightMapSaturation: { value: params.lightMapSaturation || DEFAULT_LIGHT_MAP_SATURATION },
         normalMap: { value: params.normalMap || null },
         normalScale: { value: params.normalScale || DEFAULT_NORMAL_MAP_FACTOR },
         shininess: { value: params.shininess || 1.0 },

--- a/src/aframe/three/data3d-view/io3d-material/fragment.glsl
+++ b/src/aframe/three/data3d-view/io3d-material/fragment.glsl
@@ -165,8 +165,8 @@ void main() {
 
         #ifdef USE_LIGHTMAP
             // Compute lightmap with saturation
-            const vec3 W = vec3(0.2125, 0.7154, 0.0721); // ITU-R grayscale conversion // vs NTSC vec3(0.299, 0.587, 0.114
-            vec3 col_lightMap = texture2D( lightMap, vUv2 ).xyz;
+            const vec3 W = vec3(0.2125, 0.7154, 0.0721); // ITU-R grayscale conversion
+            vec3 col_lightMap = texture2D( lightMap, vUv2 ).rgb;
             vec3 bw_lightMap = vec3(dot(col_lightMap, W));
             vec3 sat_lightMap = vec3(mix(bw_lightMap, col_lightMap, lightMapSaturation));
             // compute the light value

--- a/src/aframe/three/data3d-view/io3d-material/fragment.glsl
+++ b/src/aframe/three/data3d-view/io3d-material/fragment.glsl
@@ -18,6 +18,7 @@ uniform float opacity;
 	uniform float lightMapIntensity;
 	uniform float lightMapExposure;
 	uniform float lightMapFalloff;
+	uniform float lightMapSaturation;
 #endif
 
 #include <normalmap_pars_fragment>
@@ -163,10 +164,14 @@ void main() {
         vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
         #ifdef USE_LIGHTMAP
-
+            // Compute lightmap with saturation
+            const vec3 W = vec3(0.2125, 0.7154, 0.0721); // ITU-R grayscale conversion // vs NTSC vec3(0.299, 0.587, 0.114
+            vec3 col_lightMap = texture2D( lightMap, vUv2 ).xyz;
+            vec3 bw_lightMap = vec3(dot(col_lightMap, W));
+            vec3 sat_lightMap = vec3(mix(bw_lightMap, col_lightMap, lightMapSaturation));
             // compute the light value
             vec3 unit = vec3(1.0);
-            vec3 light = 2.0 * (texture2D( lightMap, vUv2 ).xyz - lightMapExposure * unit);
+            vec3 light = 2.0 * (sat_lightMap - lightMapExposure * unit);
             // compute the light intensity modifier
             vec3 modifier = -lightMapFalloff * light * light + unit;
             // apply light

--- a/src/aframe/three/data3d-view/set-material.js
+++ b/src/aframe/three/data3d-view/set-material.js
@@ -25,7 +25,8 @@ var LO_RES_TEXTURE_TYPES = {
 
 var DEFAULT_LIGHT_MAP_INTENSITY = 1.2
 var DEFAULT_LIGHT_MAP_EXPOSURE = 0.6
-var DEFAULT_LIGHT_MAP_FALLOFF = 0
+var DEFAULT_LIGHT_MAP_FALLOFF = 0.0
+var DEFAULT_LIGHT_MAP_SATURATION = 1.0
 
 // RepeatWrapping: 1000 / ClampToEdgeWrapping: 1001 / MirroredRepeatWrapping: 1002
 
@@ -43,6 +44,7 @@ export default function setMaterial (args) {
   var onFirstTextureSetLoaded = args.onFirstTextureSetLoaded
   var lightMapIntensity = args.lightMapIntensity
   var lightMapExposure = args.lightMapExposure
+  var lightMapSaturation = args.lightMapSaturation
 
 
   material3d.userData = material3d.userData || {}
@@ -185,9 +187,11 @@ export default function setMaterial (args) {
     material3d.lightMapIntensity = (lmi >= 0.0) ? lmi : 0.0
     material3d.lightMapExposure = lme
     material3d.lightMapFalloff = (_attributes.mapLightFalloff !== undefined) ? _attributes.mapLightFalloff : DEFAULT_LIGHT_MAP_FALLOFF
+    material3d.lightMapSaturation = (lightMapSaturation !== undefined) ? lightMapSaturation : DEFAULT_LIGHT_MAP_SATURATION
     material3d.uniforms.lightMapIntensity.value = material3d.lightMapIntensity
     material3d.uniforms.lightMapExposure.value = material3d.lightMapExposure
     material3d.uniforms.lightMapFalloff.value = material3d.lightMapFalloff
+    material3d.uniforms.lightMapSaturation.value = material3d.lightMapSaturation
   }
 
   // shadows


### PR DESCRIPTION
Scope & Features:
- This PR implement a lightmap saturation control for the io3d-data3d aframe component
- The changes allow the user to have full control over the look of their scene
    
 Design:
-  The shader has been rewritten to use 'saturation' as a control mechanism for color bleeding in lightmaps
-  Grayscale conversion: used  ITU-R `(0.2125, 0.7154, 0.0721)´ (other option would be NTSC vec3(0.299, 0.587, 0.114)
- [Issue](https://github.com/archilogic-com/3dio-js/issues/85)
    
How to use:
- Set lightMapSaturation value from 0.0 (grayscale) to 1.0 (original) to 1.0+ (oversaturated) `<a-entity io3d-data3d="key:/key.gz.data3d.buffer; lightMapSaturation: 0.0"></a-entity>`
- Changes do not affect users, fallback value is neutral

How to test:
- Test (with a colorful scene) if saturation works as intended
- Check if aframe sliders work as intended

Thanks