### PR TITLE
Expose io3d and IO3D consistently in browser environment

### DIFF
--- a/src/io3d.js
+++ b/src/io3d.js
@@ -40,7 +40,10 @@ var io3d = {
 
 }
 
-// create upper case alias fro main lib object in browser environment
-if (runtime.isBrowser) window.IO3D = io3d
+// create globals for main lib object in browser environment
+if (runtime.isBrowser) {
+  window.io3d = io3d
+  window.IO3D = io3d // upper case alias
+}
 
 export default io3d


### PR DESCRIPTION
This is a proposal to expose `io3d` and `IO3D` in the same way in browser environment.

- `IO3D` is currently being exposed directly: (for legacy purposes i think) https://github.com/archilogic-com/3dio-js/blob/master/src/io3d.js#L44

- `io3d` gets exposed as a module for package managers bundled by rollup: https://github.com/archilogic-com/3dio-js/blob/master/tasks/rollup.config.js#L74

- This inconsistency might be confusing in certain situations:
https://stackoverflow.com/questions/47901849/referenceerror-io3d-is-not-defined-at-react-npm-project