### PR TITLE
Temporary fix for #38 no realtime shadows on Radeon cards

### DIFF
--- a/examples-browser/aframe/index.html
+++ b/examples-browser/aframe/index.html
@@ -20,7 +20,7 @@
        note: realtime shadows require at least one light source that casts shadows
        note: fallback to material attribute from data3d file if not set
   -->
-  <a-entity id="apartment" io3d-data3d="key:/535e624259ee6b0200000484/bake/2017-07-25_14-03-12_lXOHrN/lighting.gz.data3d.buffer" position="0 0 0" shadow="receive: true"></a-entity>
+  <a-entity id="apartment" io3d-data3d="key:/535e624259ee6b0200000484/bake/2017-07-25_14-03-12_lXOHrN/lighting.gz.data3d.buffer" position="0 0 0" shadow="receive: true; cast: false"></a-entity>
   <a-entity id="couch" io3d-furniture="id:e8175ef8-da73-4c71-9321-8cca94dd7ec6" position="0.8 0 -1.6" rotation="0 -90 0" shadow="cast: true" ></a-entity>
   <a-entity id="vase" io3d-furniture="id:10a54bcf-3b9c-4518-b7ea-81c4251cf5a4" position="0.8 0 -2.7" shadow="cast: true" rotation="0.0 180.0 0.0"></a-entity>
   <a-entity id="chairA" io3d-furniture="id:9809a451-6767-4e8c-88dd-a3e622c30832" position="0.8 0 -3.2" shadow="cast: true" rotation="0.0 -90.0 0.0"></a-entity>

--- a/src/aframe/three/data3d-view/io3d-material.js
+++ b/src/aframe/three/data3d-view/io3d-material.js
@@ -52,6 +52,9 @@ export default checkDependencies ({
   Io3dMaterial.prototype = Object.create(THREE.ShaderMaterial.prototype)
   Io3dMaterial.prototype.constructor = Io3dMaterial
 
+  // FIXME: This is a workaround for missing shadows with Radeon cards, consult #38 for details
+  Io3dMaterial.prototype.isShaderMaterial = false
+
   return Io3dMaterial
 
 })


### PR DESCRIPTION
Scope & Features:
- The fix is described [here](https://github.com/archilogic-com/3dio-js/issues/38#issuecomment-356644954)

How to test:
- Run 3dio-js locally on an affected Macbook with Radeon card
- Open aframe default scene
- If shadows 👍 (and no other errors)
- if no shadows 👎 