### PR TITLE
respect user provided search limit argument

### DIFF
--- a/src/furniture/search.js
+++ b/src/furniture/search.js
@@ -21,7 +21,7 @@ export default function searchFurniture (query, options) {
       // only published furniture & let's make sure we don't have trailing or double spaces
       query: 'isPublished:true ' + query.trim().replace(/\s+/g, ' ')
     },
-    limit: 500
+    limit: limit
     // TODO: add this param once #251 https://github.com/archilogic-com/services/issues/251 is resolved
     //offset: offset
   }


### PR DESCRIPTION
**Scope & Features**
- Since commit 6685969 we haven't been respecting the `{ limit }` argument in `io3d.furniture.search` 

**Design**
- the limit parameter now uses either the argument provided by the user or falls back to the default of 50

**How to use**
- `io3d.furniture.search('chair', { limit: 5 })`


**How to test**
- compare `io3d.furniture.search('chair', { limit: 5 })` in this branch compared to master 

