### PR TITLE
Fix webpack module not found error

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -25,6 +25,4 @@ if (runtime.isBrowser) {
 // global dependencies
 
 // three.js
-// FIXME: use require alias after #126 is resolved
-//if (runtime.isNode) global.THREE = runtime.require('three')
-if (runtime.isNode) global.THREE = require('three')
+if (runtime.isNode) global.THREE = runtime.require('three')

--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -95,10 +95,13 @@ if (runtime.isBrowser) {
   }
 } else if (runtime.isReactNative) {
   // react-native polyfill
-  // badly documented at: https://github.com/facebook/react-native/blob/master/Libraries/Utilities/PerformanceLogger.js
+  // undocumented but found here: https://github.com/facebook/react-native/blob/master/Libraries/Utilities/PerformanceLogger.js
   if (!global.performance) {
     global.performance = {
-      now: global.nativePerformanceNow
+      now: global.nativePerformanceNow 
+    }
+    if (!global.performance.now) {
+      throw new Error('Missing global performance-now polyfill')
     }
   }
 }

--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -76,7 +76,6 @@ if (Object.assign === undefined) {
 
 // performance.now()
 if (runtime.isBrowser) {
-
   // browser polyfill
   // inspired by:
   // https://gist.github.com/paulirish/5438650
@@ -85,19 +84,27 @@ if (runtime.isBrowser) {
   if (!window.performance) {
     window.performance = {}
   }
-  if (!window.performance.now){
-    var navigationStart = performance.timing ? performance.timing.navigationStart : null
+  if (!window.performance.now) {
+    var navigationStart = performance.timing
+      ? performance.timing.navigationStart
+      : null
     var nowOffset = navigationStart || Date.now()
-    window.performance.now = function now(){
+    window.performance.now = function now() {
       return Date.now() - nowOffset
     }
   }
-
-} else {
-
+} else if (runtime.isReactNative) {
+  // react-native polyfill
+  // badly documented at: https://github.com/facebook/react-native/blob/master/Libraries/Utilities/PerformanceLogger.js
+  if (!global.performance) {
+    global.performance = {
+      now: global.nativePerformanceNow
+    }
+  }
+}
+else {
   // node: use module
   global.performance = {
     now: runtime.require('performance-now')
   }
-
 }

--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -97,9 +97,7 @@ if (runtime.isBrowser) {
 
   // node: use module
   global.performance = {
-    // FIXME: use require alias after #126 is resolved
-    //now: runtime.require('performance-now')
-    now: require('performance-now')
+    now: runtime.require('performance-now')
   }
 
 }

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -74,7 +74,9 @@ function assertBrowser(message) {
 
 // work around for react-native's metro bundler dynamic require check, see https://github.com/facebook/metro/issues/65
 function getDynamicRequire() {
-  return typeof require !== 'undefined' ? require.bind(require) : null
+  return typeof global !== undefined && typeof global.require === 'function'
+    ? global.require
+    : null
 }
 
 function getWebGlInfo () {

--- a/src/utils/file/gzip.js
+++ b/src/utils/file/gzip.js
@@ -74,13 +74,9 @@ function deflateFile (file) {
 // helpers
 
 function loadDeflateLib () {
-  // FIXME: use require alias after #126 is resolved
-  //return runtime.isBrowser ? fetchScript(PAKO_LIB.deflate.url) : Promise.resolve(runtime.require(PAKO_LIB.deflate.module))
-  return runtime.isBrowser ? fetchScript(PAKO_LIB.deflate.url) : Promise.resolve(require(PAKO_LIB.deflate.module))
+  return runtime.isBrowser ? fetchScript(PAKO_LIB.deflate.url) : Promise.resolve(runtime.require(PAKO_LIB.deflate.module))
 }
 
 function loadInflateLib () {
-  // FIXME: use require alias after #126 is resolved
-  //return runtime.isBrowser ? fetchScript(PAKO_LIB.inflate.url) : Promise.resolve(runtime.require(PAKO_LIB.inflate.module))
-  return runtime.isBrowser ? fetchScript(PAKO_LIB.inflate.url) : Promise.resolve(require(PAKO_LIB.inflate.module))
+  return runtime.isBrowser ? fetchScript(PAKO_LIB.inflate.url) : Promise.resolve(runtime.require(PAKO_LIB.inflate.module))
 }

--- a/src/utils/io/fetch.js
+++ b/src/utils/io/fetch.js
@@ -4,9 +4,7 @@ export default (function(){
 
   if (runtime.isNode) {
     // overwrite whatwg-fetch polyfill
-    // FIXME: use require alias after #126 is resolved
-    //global.fetch = runtime.require('node-fetch')
-    global.fetch = require('node-fetch')
+    global.fetch = runtime.require('node-fetch')
     return global.fetch
   } else if (typeof fetch !== 'undefined') {
     return fetch

--- a/src/utils/io/form-data.js
+++ b/src/utils/io/form-data.js
@@ -2,9 +2,7 @@ import runtime from '../../core/runtime.js'
 
 var FormData_
 if (runtime.isNode) {
-  // FIXME: use require alias after #126 is resolved
-  //FormData_ = runtime.require('form-data')
-  FormData_ = require('form-data')
+  FormData_ = runtime.require('form-data')
 } else if (typeof FormData !== 'undefined') {
   FormData_ = FormData
 } else {


### PR DESCRIPTION
**Scope & Features**
- Fixes https://github.com/archilogic-com/3dio-js/issues/126

**Design**
- assigns global.require to runtime.require 

**How to use**
- `runtime.require('performance-now')`

**How to test**

Tested on
- react-native
- webpack node.js
- webpack (create-react-app)
- umd browser <script>

**Notes**

Also includes a polyfill for performance.now() which was needed for 3dio to build