### PR TITLE
Remove require alias

### DIFF
--- a/src/core/bootstrap.js
+++ b/src/core/bootstrap.js
@@ -25,4 +25,4 @@ if (runtime.isBrowser) {
 // global dependencies
 
 // three.js
-if (runtime.isNode) global.THREE = runtime.require('three')
+if (runtime.isNode) global.THREE = require('three')

--- a/src/core/polyfills.js
+++ b/src/core/polyfills.js
@@ -108,6 +108,6 @@ if (runtime.isBrowser) {
 else {
   // node: use module
   global.performance = {
-    now: runtime.require('performance-now')
+    now: require('performance-now')
   }
 }

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -60,8 +60,6 @@ var runtime = {
     license: packageJson.license
   },
 
-  require: getDynamicRequire()
-
 }
 
 export default runtime
@@ -70,22 +68,6 @@ export default runtime
 
 function assertBrowser(message) {
   if (!isBrowser) throw (message || 'Sorry this feature requires a browser environment.')
-}
-
-// work around for react-native's metro bundler dynamic require check, see https://github.com/facebook/metro/issues/65
-function getDynamicRequire() {
-  if (typeof global !== 'undefined' && typeof global.require === 'function') {
-    // react-native
-    return global.require
-  } else if (typeof require === 'function') {
-    // node and compatible
-    return require
-  } else {
-    return function throwRequireNotAvailableError(){
-      throw new Error('"require" function not available in this context. Help us to improve '+
-        '3dio.js by reporting this issue: https://github.com/archilogic-com/3dio-js/issues/new')
-    }
-  }
 }
 
 function getWebGlInfo () {

--- a/src/utils/file/gzip.js
+++ b/src/utils/file/gzip.js
@@ -74,9 +74,9 @@ function deflateFile (file) {
 // helpers
 
 function loadDeflateLib () {
-  return runtime.isBrowser ? fetchScript(PAKO_LIB.deflate.url) : Promise.resolve(runtime.require(PAKO_LIB.deflate.module))
+  return runtime.isBrowser ? fetchScript(PAKO_LIB.deflate.url) : Promise.resolve(require(PAKO_LIB.deflate.module))
 }
 
 function loadInflateLib () {
-  return runtime.isBrowser ? fetchScript(PAKO_LIB.inflate.url) : Promise.resolve(runtime.require(PAKO_LIB.inflate.module))
+  return runtime.isBrowser ? fetchScript(PAKO_LIB.inflate.url) : Promise.resolve(require(PAKO_LIB.inflate.module))
 }

--- a/src/utils/io/fetch.js
+++ b/src/utils/io/fetch.js
@@ -4,7 +4,7 @@ export default (function(){
 
   if (runtime.isNode) {
     // overwrite whatwg-fetch polyfill
-    global.fetch = runtime.require('node-fetch')
+    global.fetch = require('node-fetch')
     return global.fetch
   } else if (typeof fetch !== 'undefined') {
     return fetch

--- a/src/utils/io/form-data.js
+++ b/src/utils/io/form-data.js
@@ -2,7 +2,7 @@ import runtime from '../../core/runtime.js'
 
 var FormData_
 if (runtime.isNode) {
-  FormData_ = runtime.require('form-data')
+  FormData_ = require('form-data')
 } else if (typeof FormData !== 'undefined') {
   FormData_ = FormData
 } else {


### PR DESCRIPTION
**Scope & Features**

This PR removes the `require` alias's which were introduced as a work-around for the metro bundler, used by React Native, which does not support dynamic `require` statements as they were used in 3dio-js. 

Webpack doesn't allow for any references to ` require ` which are not being used for import purposes..leading to the webpack error `cannot find module "."`: https://github.com/archilogic-com/3dio-js/issues/126

We attempted to get around this by accessing `require` as `global.require` however this caused some issues in node.js.

**Design**

Reverts back to using `require` as it should be :)

**How to test**

Webpack:

```
npm install -g create-react-app
create-react-app require-test
npm install git://github.com/archilogic-com/3dio-js.git#require-fix
```

Browser & node.js:

Check that the samples in the examples folder are running.

**Notes**

This will cause an incompatibility for React Native + 3dio.js. I will update my RN compatible fork at https://github.com/bnjm/3dio-js incase there are any affected users.

